### PR TITLE
[REF] remplaces dyn PttEngine with static dispatch

### DIFF
--- a/app/backend/src/platform/linux.rs
+++ b/app/backend/src/platform/linux.rs
@@ -44,7 +44,7 @@ impl PttEngine for LinuxEngine {
     }
 }
 
-pub fn get_engine() -> &'static dyn PttEngine {
+pub fn get_engine() -> &'static LinuxEngine {
     static ENGINE: LinuxEngine = LinuxEngine;
     &ENGINE
 }

--- a/app/backend/src/platform/macos.rs
+++ b/app/backend/src/platform/macos.rs
@@ -245,7 +245,7 @@ impl PttEngine for MacosEngine {
     }
 }
 
-pub fn get_engine() -> &'static dyn PttEngine {
+pub fn get_engine() -> &'static MacosEngine {
     static ENGINE: MacosEngine = MacosEngine;
     &ENGINE
 }

--- a/app/backend/src/platform/mod.rs
+++ b/app/backend/src/platform/mod.rs
@@ -46,9 +46,15 @@ pub trait PttEngine: Send + Sync {
     ) -> Result<()>;
 }
 
+#[cfg(target_os = "macos")]
+pub type Engine = macos::MacosEngine;
+
+#[cfg(target_os = "linux")]
+pub type Engine = linux::LinuxEngine;
+
 /// Returns a reference to the global `PttEngine` implementation for the current platform.
 #[must_use]
-pub fn get_engine() -> &'static dyn PttEngine {
+pub fn get_engine() -> &'static Engine {
     #[cfg(target_os = "macos")]
     return macos::get_engine();
 


### PR DESCRIPTION
it's a micro optimisation but since the platform is determined strictly by compilation flags, dynamic dispatch (vtable loookup) was unnecessary overhead.