### PR TITLE
[FIX] extension: always go to call before share screen

### DIFF
--- a/extension/src/call_action_registry.ts
+++ b/extension/src/call_action_registry.ts
@@ -1,6 +1,7 @@
 type CallActionDefinitionBase = {
     id: string;
     requiresUserGesture?: boolean;
+    requiresFocusCallTab?: boolean;
     appCommands?: readonly string[];
 };
 
@@ -158,6 +159,7 @@ export const CALL_ACTIONS = defineCallActions({
         id: "toggle-screen",
         requiresValue: false,
         requiresUserGesture: false,
+        requiresFocusCallTab: true,
         run: toggleScreenInTab
     },
     OpenPip: {
@@ -203,6 +205,7 @@ export const CALL_ACTIONS = defineCallActions({
         id: "set-screen",
         requiresValue: true,
         requiresUserGesture: false,
+        requiresFocusCallTab: true,
         run: setScreenInTab,
         appCommands: ["update-screen"]
     }

--- a/extension/src/call_actions.ts
+++ b/extension/src/call_actions.ts
@@ -102,6 +102,11 @@ export function requiresUserGesture(action: CallAction): boolean {
     return CALL_ACTIONS_BY_ID[action.type].requiresUserGesture === true;
 }
 
+export function requiresFocusCallTab(action: CallAction): boolean {
+    const definition = CALL_ACTIONS_BY_ID[action.type] as { requiresFocusCallTab?: boolean };
+    return definition.requiresFocusCallTab === true;
+}
+
 function hasActionValue(action: CallAction): action is Extract<CallAction, { value: boolean }> {
     return "value" in action;
 }
@@ -136,7 +141,7 @@ export async function executeCallAction(
     action: CallAction,
     options: CallActionOptions = {}
 ): Promise<CallActionResult> {
-    if (options.focusCallTab) {
+    if (options.focusCallTab || requiresFocusCallTab(action)) {
         await focusCallTab();
     }
     const definition = CALL_ACTIONS_BY_ID[action.type];


### PR DESCRIPTION
If we don't go to the call tab before share screen, it is not possible to get the popup with the screen selection.