### PR TITLE
[REF] backend: rightsize atomic memory orderings

### DIFF
--- a/app/backend/src/api/commands.rs
+++ b/app/backend/src/api/commands.rs
@@ -161,7 +161,7 @@ pub fn quit_app(app_handle: tauri::AppHandle) {
 #[allow(clippy::needless_pass_by_value, reason = "tauri API")]
 #[must_use]
 pub fn get_ws_port(state: State<'_, WsState>) -> u16 {
-    state.port.load(Ordering::SeqCst)
+    state.port.load(Ordering::Relaxed)
 }
 
 #[tauri::command]
@@ -185,7 +185,7 @@ pub fn update_ws_port(
             let _ = store.save();
         }
 
-        let current_port = state.port.load(Ordering::SeqCst);
+        let current_port = state.port.load(Ordering::Relaxed);
         if current_port == port {
             let _ = app_handle.emit(
                 "ws-server-status",
@@ -197,7 +197,7 @@ pub fn update_ws_port(
             info!("WS server port unchanged, frontend notified.");
             return;
         }
-        state.port.store(port, Ordering::SeqCst);
+        state.port.store(port, Ordering::Relaxed);
 
         // Shutdown previous server
         // SAFETY: Mutex poisoning is fatal/unrecoverable in this context

--- a/app/backend/src/api/ws_server.rs
+++ b/app/backend/src/api/ws_server.rs
@@ -30,13 +30,13 @@ static CONNECTION_COUNT: AtomicUsize = AtomicUsize::new(0);
 static CURRENT_SERVER_ID: AtomicU64 = AtomicU64::new(0);
 
 pub fn is_connected() -> bool {
-    CONNECTION_COUNT.load(Ordering::SeqCst) > 0
+    CONNECTION_COUNT.load(Ordering::Acquire) > 0
 }
 
 // Helper for testing
 pub fn reset_connection_count() {
-    CONNECTION_COUNT.store(0, Ordering::SeqCst);
-    CURRENT_SERVER_ID.store(0, Ordering::SeqCst);
+    CONNECTION_COUNT.store(0, Ordering::Release);
+    CURRENT_SERVER_ID.store(0, Ordering::Release);
 }
 
 pub async fn start_ws_server<R: tauri::Runtime>(
@@ -46,8 +46,8 @@ pub async fn start_ws_server<R: tauri::Runtime>(
     app_handle: tauri::AppHandle<R>,
     conn_tx: crossbeam_channel::Sender<bool>,
 ) {
-    let server_id = CURRENT_SERVER_ID.fetch_add(1, Ordering::SeqCst) + 1;
-    CONNECTION_COUNT.store(0, Ordering::SeqCst);
+    let server_id = CURRENT_SERVER_ID.fetch_add(1, Ordering::AcqRel) + 1;
+    CONNECTION_COUNT.store(0, Ordering::Release);
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = match TcpListener::bind(&addr).await {
         Ok(l) => l,
@@ -108,7 +108,7 @@ async fn handle_connection<R: tauri::Runtime>(
     mut shutdown_rx: broadcast::Receiver<()>,
     server_id: u64,
 ) {
-    let is_current_server = |id| CURRENT_SERVER_ID.load(Ordering::SeqCst) == id;
+    let is_current_server = |id| CURRENT_SERVER_ID.load(Ordering::Acquire) == id;
     let callback = |request: &handshake::server::Request, response: handshake::server::Response| {
         info!("Received handshake request from: {:?}", addr);
         for (name, value) in request.headers() {
@@ -126,7 +126,7 @@ async fn handle_connection<R: tauri::Runtime>(
     };
     info!("New WebSocket connection from: {}", addr);
     let counted = if is_current_server(server_id) {
-        if CONNECTION_COUNT.fetch_add(1, Ordering::SeqCst) == 0 {
+        if CONNECTION_COUNT.fetch_add(1, Ordering::AcqRel) == 0 {
             let _ = conn_tx.send(true);
         }
         true
@@ -241,7 +241,7 @@ async fn handle_connection<R: tauri::Runtime>(
     }
     if counted
         && is_current_server(server_id)
-        && CONNECTION_COUNT.fetch_sub(1, Ordering::SeqCst) == 1
+        && CONNECTION_COUNT.fetch_sub(1, Ordering::AcqRel) == 1
     {
         let _ = conn_tx.send(false);
         let payload = encode_ws_connection(ipc_protocol::ConnectionStatus::Disconnected);

--- a/app/backend/src/lib.rs
+++ b/app/backend/src/lib.rs
@@ -126,5 +126,5 @@ pub fn run() {
 
     // Cleanup: Send shutdown to WS server if still running
     let _ = ws_shutdown_tx.send(());
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true, Ordering::Release);
 }

--- a/app/backend/src/ptt_engine/linux_x11.rs
+++ b/app/backend/src/ptt_engine/linux_x11.rs
@@ -56,15 +56,15 @@ impl PttEngine for LinuxX11Engine {
     fn set_binding(&self, binding: KeyBinding) {
         let packed = pack_binding(binding);
         debug!("Setting binding: {:?} (packed: {})", binding, packed);
-        BINDING_PACKED.store(packed, Ordering::SeqCst);
+        BINDING_PACKED.store(packed, Ordering::Release);
     }
 
     fn set_recording(&self, recording: bool) {
-        IS_RECORDING.store(recording, Ordering::SeqCst);
+        IS_RECORDING.store(recording, Ordering::Release);
     }
 
     fn get_binding(&self) -> KeyBinding {
-        binding_from_packed(BINDING_PACKED.load(Ordering::SeqCst))
+        binding_from_packed(BINDING_PACKED.load(Ordering::Acquire))
     }
 
     fn force_ptt_up(&self) {
@@ -125,11 +125,11 @@ pub fn get_engine() -> &'static LinuxX11Engine {
 }
 
 fn set_ptt_held(held: bool) {
-    HELD.store(held, Ordering::SeqCst);
+    HELD.store(held, Ordering::Release);
 }
 
 fn get_ptt_state() -> PttState {
-    if HELD.load(Ordering::SeqCst) {
+    if HELD.load(Ordering::Acquire) {
         PttState::Held
     } else {
         PttState::Idle
@@ -271,9 +271,9 @@ fn handle_key_event(type_code: i32, keycode: u8, state: u32) {
         x11_keycode, keycode, state, modifiers_mask, modifiers
     );
 
-    let packed_binding = BINDING_PACKED.load(Ordering::SeqCst);
+    let packed_binding = BINDING_PACKED.load(Ordering::Acquire);
     let (binding_code, binding_mask) = unpack_binding(packed_binding);
-    let recording = IS_RECORDING.load(Ordering::SeqCst);
+    let recording = IS_RECORDING.load(Ordering::Acquire);
 
     let ts = current_timestamp();
 
@@ -592,7 +592,7 @@ fn spawn_shutdown_thread(
             reason = "Restoring pointer from usize for FFI"
         )]
         let dpy = dpy_ctrl_usize as *mut Display;
-        while !shutdown.load(Ordering::SeqCst) {
+        while !shutdown.load(Ordering::Relaxed) {
             thread::sleep(Duration::from_millis(500));
         }
         debug!("Shutting down XRecord context");

--- a/app/backend/src/ptt_engine/linux_xdg.rs
+++ b/app/backend/src/ptt_engine/linux_xdg.rs
@@ -45,7 +45,7 @@ impl PttEngine for LinuxXdgEngine {
         shutdown: &Arc<AtomicBool>,
     ) -> Result<()> {
         warn!("start_engine not implemented for Linux. Waiting for shutdown.");
-        while !shutdown.load(Ordering::SeqCst) {
+        while !shutdown.load(Ordering::Relaxed) {
             thread::sleep(Duration::from_millis(100));
         }
         Ok(())

--- a/app/backend/src/ptt_engine/macos.rs
+++ b/app/backend/src/ptt_engine/macos.rs
@@ -111,21 +111,21 @@ pub struct MacosEngine;
 
 impl PttEngine for MacosEngine {
     fn set_binding(&self, binding: KeyBinding) {
-        BINDING_PACKED.store(pack_binding(binding), Ordering::SeqCst);
+        BINDING_PACKED.store(pack_binding(binding), Ordering::Release);
     }
 
     fn set_recording(&self, recording: bool) {
-        IS_RECORDING.store(recording, Ordering::SeqCst);
+        IS_RECORDING.store(recording, Ordering::Release);
     }
 
     fn get_binding(&self) -> KeyBinding {
-        binding_from_packed(BINDING_PACKED.load(Ordering::SeqCst))
+        binding_from_packed(BINDING_PACKED.load(Ordering::Acquire))
     }
 
     fn force_ptt_up(&self) {
         info!("Forcing PTT UP (Safety Release)");
         set_ptt_held(false);
-        PRIMARY_KEY_HELD.store(false, Ordering::SeqCst);
+        PRIMARY_KEY_HELD.store(false, Ordering::Release);
 
         let binding = self.get_binding();
         let ts = current_timestamp();
@@ -193,7 +193,7 @@ impl PttEngine for MacosEngine {
             )
         };
 
-        GLOBAL_TAP.store(tap.cast::<c_void>(), Ordering::SeqCst);
+        GLOBAL_TAP.store(tap.cast::<c_void>(), Ordering::Release);
 
         if tap.is_null() {
             error!("Failed to create event tap - NULL return");
@@ -240,7 +240,7 @@ impl PttEngine for MacosEngine {
 
         info!("Event tap started, listening for PTT key events");
 
-        while !shutdown.load(Ordering::SeqCst) {
+        while !shutdown.load(Ordering::Relaxed) {
             #[allow(
                 unsafe_code,
                 reason = "
@@ -262,7 +262,7 @@ pub fn get_engine() -> &'static MacosEngine {
 }
 
 fn get_ptt_state() -> PttState {
-    if HELD.load(Ordering::SeqCst) {
+    if HELD.load(Ordering::Acquire) {
         PttState::Held
     } else {
         PttState::Idle
@@ -270,7 +270,7 @@ fn get_ptt_state() -> PttState {
 }
 
 fn set_ptt_held(held: bool) {
-    HELD.store(held, Ordering::SeqCst);
+    HELD.store(held, Ordering::Release);
 }
 
 fn send_event(msg: OutgoingMessage) {
@@ -296,7 +296,7 @@ extern "C" fn event_callback(
     if event_type == K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT
         || event_type == K_CG_EVENT_TAP_DISABLED_BY_USER_INTEREST
     {
-        let tap = GLOBAL_TAP.load(Ordering::SeqCst);
+        let tap = GLOBAL_TAP.load(Ordering::Acquire);
         if !tap.is_null() {
             info!(
                 "Event tap disabled by system (type={}), re-enabling...",
@@ -360,15 +360,15 @@ extern "C" fn event_callback(
     // 1. Binding changes are rare (user-initiated configuration)
     // 2. The worst case is a single PTT event firing slightly early or late
     // 3. The next event will use consistent state
-    let packed_binding = BINDING_PACKED.load(Ordering::SeqCst);
+    let packed_binding = BINDING_PACKED.load(Ordering::Acquire);
     let (binding_code, binding_mask) = unpack_binding(packed_binding);
-    let recording = IS_RECORDING.load(Ordering::SeqCst);
+    let recording = IS_RECORDING.load(Ordering::Acquire);
     let mut is_repeat = false;
 
     // Track primary key state
     if event_type == K_CG_EVENT_KEY_DOWN {
         if keycode == binding_code {
-            PRIMARY_KEY_HELD.store(true, Ordering::SeqCst);
+            PRIMARY_KEY_HELD.store(true, Ordering::Release);
         }
         #[allow(
             unsafe_code,
@@ -381,10 +381,10 @@ extern "C" fn event_callback(
             is_repeat = CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_AUTOREPEAT) != 0;
         }
     } else if event_type == K_CG_EVENT_KEY_UP && keycode == binding_code {
-        PRIMARY_KEY_HELD.store(false, Ordering::SeqCst);
+        PRIMARY_KEY_HELD.store(false, Ordering::Release);
     }
 
-    let primary_held = PRIMARY_KEY_HELD.load(Ordering::SeqCst);
+    let primary_held = PRIMARY_KEY_HELD.load(Ordering::Acquire);
     let current_ptt_state = get_ptt_state();
     debug!(
         "State: primary_held={} target={} recording={}",
@@ -527,9 +527,9 @@ mod tests {
     fn test_recording_toggle() {
         let engine = MacosEngine;
         engine.set_recording(true);
-        assert!(IS_RECORDING.load(Ordering::SeqCst));
+        assert!(IS_RECORDING.load(Ordering::Acquire));
         engine.set_recording(false);
-        assert!(!IS_RECORDING.load(Ordering::SeqCst));
+        assert!(!IS_RECORDING.load(Ordering::Acquire));
     }
 
     #[test]

--- a/app/backend/src/ptt_engine/windows.rs
+++ b/app/backend/src/ptt_engine/windows.rs
@@ -45,7 +45,7 @@ impl PttEngine for WindowsEngine {
         shutdown: &Arc<AtomicBool>,
     ) -> Result<()> {
         warn!("start_engine not implemented for Windows. Waiting for shutdown.");
-        while !shutdown.load(Ordering::SeqCst) {
+        while !shutdown.load(Ordering::Relaxed) {
             thread::sleep(Duration::from_millis(100));
         }
         Ok(())


### PR DESCRIPTION
Replace most of the `SeqCst` aperotions with orderings that match actual synchronization needs. Behavior is unchanged; no path requires a global total order across independent atomics.

(todo)

| Operation         | Old    | New     | rationale |
|------------------|--------|---------|-------------------|
| `store(true)`    | SeqCst | Release | One-way stop flag (`false -> true`). `Release` is conservative; correctness only requires eventual visibility of `true`. |
| poll `load()`    | SeqCst | Relaxed | Pure termination polling loop. No dependen shared state is read via this atomic. |

| Atomic / operation                    | Old    | New     | rationale |
|--------------------------------------|--------|---------|-------------------|
| `CURRENT_SERVER_ID.fetch_add(1)`     | SeqCst | AcqRel  | Monotonic server generation via RMW; no cross-atomic total order needed. |
| `CONNECTION_COUNT.fetch_add/sub`     | SeqCst | AcqRel  | 0↔1 transitions raely on RMW return value (atomic modification order), not SC. |
| `CURRENT_SERVER_ID` / `CONNECTION_COUNT` `load()` | SeqCst | Acquire | Conservative read side for current generation/count checks. |
| reset `store(0)`                      | SeqCst | Release | Conservative reset semantics for tests/restart path. |

| Operation    | Old    | New     | rationale |
|-------------|--------|---------|-------------------|
| `port.load/store` | SeqCst | Relaxed | Atomic config value only; restart sequencing is coordinated by mutex + broadcast channel, not atomic ordering. |

| Atomic              | Stores   | Loads    | rationale |
|---------------------|----------|----------|-------------------|
| `BINDING_PACKED`    | Release  | Acquire  | Single-value pub from command/UI path to callback path. |
| `IS_RECORDING`      | Release  | Acquire  | Same publication/observation pattern. |
| `HELD`              | Release  | Acquire  | Shared PTT state flag read/write across callback/control pats. |
| `PRIMARY_KEY_HELD`  | Release  | Acquire  | Shared key-state flag used across callback decisions. |
| `GLOBAL_TAP`        | Release  | Acquire  | Tap pointer published before callback reads/re-enable path. |

### Checklist
- [x] I read and followed the guidelines in [`CONTRIBUTING.md`](https://github.com/ThanhDodeurOdoo/discuss-companion/blob/master/CONTRIBUTING.md)
- [ ] I added tests to cover the changes (if applicable)
- [ ] I added or updated docs (if applicable)
