### PR TITLE
[IMP] extension: probe for odoo before injecting runtime

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,6 +1,6 @@
 (async () => {
     try {
-        await import(chrome.runtime.getURL("content_bundle.js"));
+        await import(chrome.runtime.getURL("content_bootstrap.js"));
     } catch (error) {
         console.error("[Discuss Companion] Failed to load content script", error);
     }

--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Discuss Companion Bridge",
     "description": "Bridge extension to connect to the Discuss Companion app",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "homepage_url": "https://github.com/ThanhDodeurOdoo/discuss-companion",
     "browser_specific_settings": {
         "gecko": {
@@ -47,7 +47,9 @@
     "web_accessible_resources": [
         {
             "resources": [
+                "content_bootstrap.js",
                 "page_bridge.js",
+                "page_probe.js",
                 "content_bundle.js",
                 "assets/*.js"
             ],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Discuss Companion Bridge",
     "description": "Bridge extension to connect to the Discuss Companion app",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "homepage_url": "https://github.com/ThanhDodeurOdoo/discuss-companion",
     "permissions": [
         "storage",
@@ -34,7 +34,9 @@
     "web_accessible_resources": [
         {
             "resources": [
+                "content_bootstrap.js",
                 "page_bridge.js",
+                "page_probe.js",
                 "content_bundle.js",
                 "assets/*.js"
             ],

--- a/extension/src/content/bootstrap.ts
+++ b/extension/src/content/bootstrap.ts
@@ -1,0 +1,103 @@
+export const CONTENT_BOOTSTRAP_CHANNEL = "discuss-companion-bootstrap";
+
+type ContentBootstrapDeps = {
+    loadContentRuntime: () => Promise<void>;
+    probePageForOdoo: () => Promise<boolean>;
+};
+
+type OdooProbeMessage = {
+    channel: typeof CONTENT_BOOTSTRAP_CHANNEL;
+    hasOdoo: boolean;
+};
+
+function isOdooProbeMessage(value: unknown): value is OdooProbeMessage {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+    const message = value as { channel?: unknown; hasOdoo?: unknown };
+    return message.channel === CONTENT_BOOTSTRAP_CHANNEL && typeof message.hasOdoo === "boolean";
+}
+
+async function loadContentRuntime(): Promise<void> {
+    await import(chrome.runtime.getURL("content_bundle.js"));
+}
+
+async function probePageForOdoo(): Promise<boolean> {
+    const target = document.head ?? document.documentElement;
+    if (!target) {
+        return false;
+    }
+
+    return new Promise((resolve) => {
+        const script = document.createElement("script");
+        const timeoutId = window.setTimeout(() => {
+            cleanup();
+            resolve(false);
+        }, 1000);
+
+        const cleanup = () => {
+            window.clearTimeout(timeoutId);
+            window.removeEventListener("message", handleMessage);
+            script.remove();
+        };
+
+        const handleMessage = (event: MessageEvent) => {
+            if (event.source !== window || event.origin !== location.origin) {
+                return;
+            }
+            if (!isOdooProbeMessage(event.data)) {
+                return;
+            }
+            cleanup();
+            resolve(event.data.hasOdoo);
+        };
+
+        window.addEventListener("message", handleMessage);
+        script.src = chrome.runtime.getURL("page_probe.js");
+        script.async = false;
+        script.onerror = () => {
+            cleanup();
+            resolve(false);
+        };
+        target.appendChild(script);
+    });
+}
+
+export function startContentBootstrap(
+    deps: ContentBootstrapDeps = { loadContentRuntime, probePageForOdoo }
+): void {
+    let runtimeLoaded = false;
+    let probePromise: Promise<boolean> | null = null;
+
+    const onReady = () => {
+        if (runtimeLoaded) {
+            return;
+        }
+        if (!probePromise) {
+            probePromise = deps.probePageForOdoo().finally(() => {
+                probePromise = null;
+            });
+        }
+        void probePromise.then((hasOdoo) => {
+            if (!hasOdoo || runtimeLoaded) {
+                return;
+            }
+            runtimeLoaded = true;
+            document.removeEventListener("DOMContentLoaded", onReady);
+            window.removeEventListener("load", onReady);
+            void deps.loadContentRuntime().catch((error) => {
+                runtimeLoaded = false;
+                console.error("[Discuss Companion] Failed to load content runtime", error);
+            });
+        });
+    };
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", onReady, { once: true });
+    }
+    if (document.readyState !== "complete") {
+        window.addEventListener("load", onReady, { once: true });
+    }
+
+    onReady();
+}

--- a/extension/src/content_bootstrap.ts
+++ b/extension/src/content_bootstrap.ts
@@ -1,0 +1,3 @@
+import { startContentBootstrap } from "@extension/src/content/bootstrap";
+
+startContentBootstrap();

--- a/extension/src/page_probe.ts
+++ b/extension/src/page_probe.ts
@@ -1,0 +1,13 @@
+const CONTENT_BOOTSTRAP_CHANNEL = "discuss-companion-bootstrap";
+
+type ProbeWindow = typeof globalThis & {
+    odoo?: unknown;
+};
+
+window.postMessage(
+    {
+        channel: CONTENT_BOOTSTRAP_CHANNEL,
+        hasOdoo: Boolean((globalThis as ProbeWindow).odoo)
+    },
+    location.origin
+);

--- a/extension/tests/content_bootstrap.test.js
+++ b/extension/tests/content_bootstrap.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://odoo.com/"}
+ */
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import { flushPromises } from "./utils.js";
+import { startContentBootstrap } from "../src/content/bootstrap";
+
+describe("content bootstrap", () => {
+    let readyState = "complete";
+
+    beforeEach(() => {
+        readyState = "complete";
+        Object.defineProperty(document, "readyState", {
+            configurable: true,
+            get: () => readyState
+        });
+    });
+
+    test("loads the runtime immediately when Odoo is detected", async () => {
+        const loadContentRuntime = jest.fn().mockResolvedValue(undefined);
+        const probePageForOdoo = jest.fn().mockResolvedValue(true);
+
+        startContentBootstrap({ loadContentRuntime, probePageForOdoo });
+        await flushPromises();
+
+        expect(probePageForOdoo).toHaveBeenCalledTimes(1);
+        expect(loadContentRuntime).toHaveBeenCalledTimes(1);
+    });
+
+    test("retries on document readiness events before loading the runtime", async () => {
+        readyState = "loading";
+        const loadContentRuntime = jest.fn().mockResolvedValue(undefined);
+        const probePageForOdoo = jest
+            .fn()
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(true);
+
+        startContentBootstrap({ loadContentRuntime, probePageForOdoo });
+        await flushPromises();
+
+        document.dispatchEvent(new Event("DOMContentLoaded"));
+        await flushPromises();
+        expect(loadContentRuntime).not.toHaveBeenCalled();
+
+        readyState = "complete";
+        window.dispatchEvent(new Event("load"));
+        await flushPromises();
+
+        expect(probePageForOdoo).toHaveBeenCalledTimes(3);
+        expect(loadContentRuntime).toHaveBeenCalledTimes(1);
+    });
+});

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -34,8 +34,10 @@ export default defineConfig(({ mode }) => {
                 input: {
                     service_worker: resolve(__dirname, "src/service_worker.ts"),
                     main: resolve(__dirname, "src/popup/main.ts"),
+                    content_bootstrap: resolve(__dirname, "src/content_bootstrap.ts"),
                     content_bundle: resolve(__dirname, "src/content.ts"),
-                    page_bridge: resolve(__dirname, "src/page_bridge.ts")
+                    page_bridge: resolve(__dirname, "src/page_bridge.ts"),
+                    page_probe: resolve(__dirname, "src/page_probe.ts")
                 },
                 output: {
                     entryFileNames: "[name].js",


### PR DESCRIPTION
Before this commit, the extension was eagerly loading the page bridge to all pages, while most what it did was gated by the presence of odoo on the page, it was still loading more than necessary on sites that were not compatible with the extension.

This commit fixes this issue by first loading a probe script that checks if the page is an odoo page before loading the rest of the runtime.

## Checklist

### General
- [x] I read and followed the guidelines in [`CONTRIBUTING.md`](https://github.com/ThanhDodeurOdoo/discuss-companion/blob/master/.github/CONTRIBUTING.md)
- [x] I added tests to cover the changes (if applicable)
- [ ] I added or updated docs (if applicable)

### AI
- [ ] The PR was written with the help of AI (ignore below if not)
- [ ] I added the AI tag
- [ ] I explained the AI's role in the commit message
